### PR TITLE
Update guzzle to 7.0 to support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {
         "symfony/var-dumper": "^4.3",


### PR DESCRIPTION
The Laravel 8 composer.json has guzzle 7.0.1 so this adds guzzle 7 as an option and the tests are green.