### PR TITLE
Add ability to pass format parameter

### DIFF
--- a/src/Geocodio.php
+++ b/src/Geocodio.php
@@ -26,7 +26,7 @@ class Geocodio
      * @see https://www.geocod.io/docs/#changelog
      */
     private $apiVersion = 'v1.7';
-    
+
     private Client $client;
 
     const ADDRESS_COMPONENT_PARAMETERS = [
@@ -65,10 +65,11 @@ class Geocodio
      * @param string|array $query
      * @param array $fields
      * @param int|null $limit
+     * @param string|null $format
      * @return array|object
      */
-    public function geocode($query, array $fields = [], int $limit = null) {
-        return $this->handleRequest('geocode', $query, $fields, $limit);
+    public function geocode($query, array $fields = [], int $limit = null, string $format = null) {
+        return $this->handleRequest('geocode', $query, $fields, $limit, $format);
     }
 
     /**
@@ -76,19 +77,21 @@ class Geocodio
      * @param string|array $query
      * @param array $fields
      * @param int|null $limit
+     * @param string|null $format
      * @return array|object
      */
-    public function reverse($query, array $fields = [], int $limit = null) {
-        return $this->handleRequest('reverse', $query, $fields, $limit);
+    public function reverse($query, array $fields = [], int $limit = null, string $format = null) {
+        return $this->handleRequest('reverse', $query, $fields, $limit, $format);
     }
 
-    private function handleRequest(string $endpoint, $query, array $fields = [], int $limit = null) {
+    private function handleRequest(string $endpoint, $query, array $fields = [], int $limit = null, string $format = null) {
         $url = $this->formatUrl($endpoint);
 
         $queryParameters = array_filter([
             'api_key' => $this->apiKey,
             'fields' => implode(',', $fields),
-            'limit' => $limit
+            'limit' => $limit,
+            'format' => $format
         ]);
 
         $query = $this->preprocessQuery($query, $endpoint);

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -10,7 +10,7 @@ class ErrorHandlingTest extends TestCase
 {
     use InteractsWithAPI;
 
-    /** @var Geocodio */
+    /**@var Geocodio */
     private $gecoder;
 
     public function setUp(): void

--- a/tests/GeocodingTest.php
+++ b/tests/GeocodingTest.php
@@ -9,7 +9,7 @@ class GeocodingTest extends TestCase
 {
     use InteractsWithAPI;
 
-    /** @var Geocodio */
+    /**@var Geocodio */
     private $gecoder;
 
     public function setUp(): void
@@ -107,5 +107,18 @@ class GeocodingTest extends TestCase
 
         $response = $this->geocoder->geocode('1107 N Highland St, Arlington VA', [], 1);
         $this->assertEquals(1, count($response->results));
+    }
+
+    public function testFormatSimpleParameter()
+    {
+        $response = $this->geocoder->geocode('1109 N Highland St, Arlington VA', [], null, 'simple');
+        $this->assertEquals('1109 N Highland St, Arlington, VA 22201', $response->address);
+        $this->assertEquals('38.886672', $response->lat);
+        $this->assertEquals('-77.094735', $response->lng);
+
+        $response = $this->geocoder->reverse('38.886672,-77.094735', [], null, 'simple');
+        $this->assertEquals('1109 N Highland St, Arlington, VA 22201', $response->address);
+        $this->assertEquals('38.886672', $response->lat);
+        $this->assertEquals('-77.094735', $response->lng);
     }
 }


### PR DESCRIPTION
This PR adds ability to pass a format parameter to `geocode` and `reverse` functions. Also it removes `NBSP` char from tests.