### PR TITLE
Updates bash install command for easier copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 You can install the package via composer:
 
 ```bash
-$ composer require geocodio/geocodio-library-php
+composer require geocodio/geocodio-library-php
 ```
 
 > Using [Laravel](https://laravel.com)? Great! There's an optional Laravel service provider, for easy integration into your app.


### PR DESCRIPTION
This PR updates the bash install command to remove the dollar sign for easier copying.