### PR TITLE
Fix return type declarations

### DIFF
--- a/src/Geocodio.php
+++ b/src/Geocodio.php
@@ -91,14 +91,13 @@ class Geocodio
      * @see https://www.geocod.io/docs/#geocoding
      *
      * @param  string|array  $query
-     * @return array|object
      */
     public function geocode(
         $query,
         array $fields = [],
         ?int $limit = null,
         ?string $format = null
-    ): mixed {
+    ): array {
         $options = [
             RequestOptions::QUERY => [
                 'fields' => implode(',', $fields),
@@ -254,14 +253,13 @@ class Geocodio
      * @see https://www.geocod.io/docs/#reverse-geocoding
      *
      * @param  string|array  $query
-     * @return array|object
      */
     public function reverse(
         $query,
         array $fields = [],
         ?int $limit = null,
         ?string $format = null
-    ): mixed {
+    ): array {
         $options = [
             RequestOptions::QUERY => [
                 'q' => $this->formattedReverseQuery($query),


### PR DESCRIPTION
Updated the return types for `geocode()` and `reverse()` methods from `mixed` to `array` to match what `toResponse()` actually returns.

Since `json_decode()` is called with `true` for the associative parameter, it always returns an array, never an object.

Fixes #17