### PR TITLE
feat: Update to Geocodio API v1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `geocodio-library-php` will be documented in this file
 
+## Unreleased
+
+- Update to use Geocodio API v1.9
+
 ## 2.4 - 2025-08-19
 
 - Added configurable HTTP timeouts for API requests

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ array:6 [
     "time_left_description" => null
     "time_left_seconds" => null
   ]
-  "download_url" => "https://api.geocod.io/v1.8/lists/11953719/download"
-  "expires_at" => "2024-09-22T20:36:10.000000Z"
+  "download_url" => "https://api.geocod.io/v1.9/lists/11953719/download"
+  "expires_at" => "2025-08-22T20:36:10.000000Z"
 ]
 */
 ```
@@ -299,13 +299,13 @@ array:9 [
         "time_left_description" => null
         "time_left_seconds" => null
       ]
-      "download_url" => "https://api.geocod.io/v1.8/lists/11953719/download"
-      "expires_at" => "2024-09-22T20:36:10.000000Z"
+      "download_url" => "https://api.geocod.io/v1.9/lists/11953719/download"
+      "expires_at" => "2025-08-22T20:36:10.000000Z"
     ]
-  "first_page_url" => "https://api.geocod.io/v1.8/lists?page=1"
+  "first_page_url" => "https://api.geocod.io/v1.9/lists?page=1"
   "from" => 1
   "next_page_url" => null
-  "path" => "https://api.geocod.io/v1.8/lists"
+  "path" => "https://api.geocod.io/v1.9/lists"
   "per_page" => 15
   "prev_page_url" => null
   "to" => 3

--- a/config/geocodio.php
+++ b/config/geocodio.php
@@ -43,6 +43,6 @@ return [
     |
     */
 
-    'api_version' => env('GEOCODIO_API_VERSION', 'v1.8'),
+    'api_version' => env('GEOCODIO_API_VERSION', 'v1.9'),
 
 ];

--- a/src/Geocodio.php
+++ b/src/Geocodio.php
@@ -31,7 +31,7 @@ class Geocodio
      *
      * @see https://www.geocod.io/docs/#changelog
      */
-    private string $apiVersion = 'v1.8';
+    private string $apiVersion = 'v1.9';
 
     /**
      * @var int Timeout for single geocoding requests in milliseconds


### PR DESCRIPTION
## Summary
- Updates all API version references from v1.8 to v1.9
- Updates README example `expires_at` dates to be current (2025-08-22)
- No breaking changes - this is a simple version bump

## Changes
- Updated API version in `src/Geocodio.php`
- Updated default API version in `config/geocodio.php`
- Updated API URLs in README examples
- Updated CHANGELOG with unreleased entry
- Updated example expiration dates to be current

## Test plan
- [x] Verify all tests pass
- [x] Confirm API calls work with v1.9 endpoint
- [x] Check that no breaking changes exist between v1.8 and v1.9