### PR TITLE
Migrate to Geocodio API v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `geocodio-library-php` will be documented in this file
 
+## 3.0.0 - 2026-06-05
+
+- **Breaking**: Migrated to Geocodio API v2
+- **Breaking**: Top-level `input` object removed from `/geocode` and `/reverse` responses; parsed address is now found inside `results[].address_components`
+- **Breaking**: Renamed address component keys: `zip` → `postal_code`, `state` → `state_province`, `secondaryunit` → `unit_type`, `secondarynumber` → `unit_number` (applies to both `address_components` and `address_components_secondary`)
+- Added `state_province` to the address component input parameter allowlist (alongside the still-accepted `state`)
+- Bumped SDK version to 3.0.0
+
 ## 2.9 - 2026-03-12
 
 - Updated default API version to v1.11

--- a/README.md
+++ b/README.md
@@ -60,20 +60,7 @@ $geocoder->setApiKey('YOUR_API_KEY');
 $response = $geocoder->geocode('1109 N Highland St, Arlington, VA');
 dump($response);
 /*
-array:2 [
-  "input" => array:2 [
-    "address_components" => array:8 [
-      "number" => "1109"
-      "predirectional" => "N"
-      "street" => "Highland"
-      "suffix" => "St"
-      "formatted_street" => "N Highland St"
-      "city" => "Arlington"
-      "state" => "VA"
-      "country" => "US"
-    ]
-    "formatted_address" => "1109 N Highland St, Arlington, VA"
-  ]
+array:1 [
   "results" => array:1 [
     0 => array:6 [
       "address_components" => array:10 [
@@ -84,8 +71,8 @@ array:2 [
         "formatted_street" => "N Highland St"
         "city" => "Arlington"
         "county" => "Arlington County"
-        "state" => "VA"
-        "zip" => "22201"
+        "state_province" => "VA"
+        "postal_code" => "22201"
         "country" => "US"
       ]
       "formatted_address" => "1109 N Highland St, Arlington, VA 22201"
@@ -166,7 +153,7 @@ For forward geocoding requests it is possible to supply [individual address comp
 $response = $geocoder->geocode([
     'street' => '1109 N Highland St',
     'city' => 'Arlington',
-    'state' => 'VA',
+    'state_province' => 'VA',
     'postal_code' => '22201'
 ]);
 
@@ -174,12 +161,12 @@ $response = $geocoder->geocode([
     [
         'street' => '1109 N Highland St',
         'city' => 'Arlington',
-        'state' => 'VA'
+        'state_province' => 'VA'
     ],
     [
         'street' => '525 University Ave',
         'city' => 'Toronto',
-        'state' => 'ON',
+        'state_province' => 'ON',
         'country' => 'Canada',
     ],
 );
@@ -270,7 +257,7 @@ array:6 [
     "time_left_description" => null
     "time_left_seconds" => null
   ]
-  "download_url" => "https://api.geocod.io/v1.11/lists/11953719/download"
+  "download_url" => "https://api.geocod.io/v2/lists/11953719/download"
   "expires_at" => "2025-08-22T20:36:10.000000Z"
 ]
 */
@@ -307,13 +294,13 @@ array:9 [
         "time_left_description" => null
         "time_left_seconds" => null
       ]
-      "download_url" => "https://api.geocod.io/v1.11/lists/11953719/download"
+      "download_url" => "https://api.geocod.io/v2/lists/11953719/download"
       "expires_at" => "2025-08-22T20:36:10.000000Z"
     ]
-  "first_page_url" => "https://api.geocod.io/v1.11/lists?page=1"
+  "first_page_url" => "https://api.geocod.io/v2/lists?page=1"
   "from" => 1
   "next_page_url" => null
-  "path" => "https://api.geocod.io/v1.11/lists"
+  "path" => "https://api.geocod.io/v2/lists"
   "per_page" => 15
   "prev_page_url" => null
   "to" => 3
@@ -410,7 +397,6 @@ $response = $geocoder->geocode(
 /*
 Response includes destinations for each geocoded result:
 [
-    'input' => [...],
     'results' => [
         [
             'formatted_address' => '1600 Pennsylvania Ave NW, Washington, DC 20500',
@@ -681,7 +667,7 @@ $status = $geocoder->distanceMatrixJobStatus($job['id']);
         'progress' => 100,
         'message' => 'Completed'
     ],
-    'download_url' => 'https://api.geocod.io/v1.9/distance-matrix/abc123/download',
+    'download_url' => 'https://api.geocod.io/v2/distance-matrix/abc123/download',
     'expires_at' => '2025-01-15T12:00:00.000000Z'
 ]
 */

--- a/config/geocodio.php
+++ b/config/geocodio.php
@@ -43,6 +43,6 @@ return [
     |
     */
 
-    'api_version' => env('GEOCODIO_API_VERSION', 'v1.11'),
+    'api_version' => env('GEOCODIO_API_VERSION', 'v2'),
 
 ];

--- a/src/Geocodio.php
+++ b/src/Geocodio.php
@@ -36,7 +36,7 @@ class Geocodio
      *
      * @see https://www.geocod.io/docs/#changelog
      */
-    private string $apiVersion = 'v1.11';
+    private string $apiVersion = 'v2';
 
     /**
      * @var int Timeout for single geocoding requests in milliseconds
@@ -67,6 +67,7 @@ class Geocodio
         'street',
         'city',
         'state',
+        'state_province',
         'postal_code',
         'country',
     ];
@@ -74,7 +75,7 @@ class Geocodio
     /**
      * Current SDK version
      */
-    const SDK_VERSION = '2.9.0';
+    const SDK_VERSION = '3.0.0';
 
     /**
      * Timeout for single geocoding requests in milliseconds

--- a/tests/GeocodingTest.php
+++ b/tests/GeocodingTest.php
@@ -46,7 +46,7 @@ describe('Forward Geocoding', function (): void {
     it('can perform batch forward geocode with components', function (): void {
         $response = $this->geocoder->geocode([
             ['street' => '1109 N Highland St', 'postal_code' => '22201'],
-            ['street' => '525 University Ave', 'city' => 'Toronto', 'state' => 'Ontario', 'country' => 'Canada'],
+            ['street' => '525 University Ave', 'city' => 'Toronto', 'state_province' => 'Ontario', 'country' => 'Canada'],
         ]);
 
         expect($response['results'][0]['response']['results'][0]['formatted_address'])


### PR DESCRIPTION
## Summary

- **Breaking change** — targets release **3.0.0** (do NOT tag/release from this PR)
- Updates default API version from `v1.11` to `v2` in both `src/Geocodio.php` and `config/geocodio.php`
- Bumps `SDK_VERSION` from `2.9.0` to `3.0.0`

## Breaking changes (API v2)

- **Top-level `input` removed**: `/geocode` and `/reverse` responses no longer contain a top-level `input` object; the parsed address is now inside `results[].address_components`
- **Renamed address component keys** (both `address_components` and `address_components_secondary`):
  - `zip` → `postal_code`
  - `state` → `state_province`
  - `secondaryunit` → `unit_type`
  - `secondarynumber` → `unit_number`
- **Input parameter**: `state_province` added to the `ADDRESS_COMPONENT_PARAMETERS` allowlist; the old `state` key is retained for backwards compatibility

## Files changed

- `src/Geocodio.php` — version, SDK constant, allowlist
- `config/geocodio.php` — default API version
- `README.md` — response examples updated to v2 shape; `state_province` in address component examples; all URL references updated
- `CHANGELOG.md` — 3.0.0 entry dated 2026-06-05
- `tests/GeocodingTest.php` — batch-with-components test updated to use `state_province`

## Test results

All mocked tests pass (ListTest, TimeoutConfigurationTest). All live geocoding/error tests pass against the real API. 11 tests in `DistanceTest` fail with `"Please purchase more credits first"` — this is a billing limitation on the test account for the Distance API, **not** a code regression. These tests were failing identically on `master` before this change.

> ⚠️ Do NOT tag or publish a Packagist release from this PR. Tagging will trigger auto-sync to Packagist.